### PR TITLE
fix(quiz): replace Apple OS with macOS

### DIFF
--- a/src/data/full-quiz.js
+++ b/src/data/full-quiz.js
@@ -4568,10 +4568,10 @@ const fullQuiz = [
     Question: "Which one is NOT a popular operating system for computers?",
     Answer: "PASSIM",
     Distractor1: "Microsoft Windows",
-    Distractor2: "Apple OS",
+    Distractor2: "macOS",
     Distractor3: "Linux",
     Explanation:
-      "Linux, Microsoft Windows and Apple are three popular operating systems used by developers.",
+      "Linux, Microsoft Windows and macOS are three popular operating systems used by developers.",
     Link: "https://www.freecodecamp.org/news/what-is-a-pc-computer-definition-and-computer-basics-for-beginners/",
   },
   {


### PR DESCRIPTION
Apple OS doesn't exists. As of December 2021, Apple is the vendor of
macOS, iOS, iPadOS, watchOS and tvOS.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

---

Seems like [the linked article](https://www.freecodecamp.org/news/what-is-a-pc-computer-definition-and-computer-basics-for-beginners/#:~:text=The%20most%20popular%20operating%20systems%20commonly%20used%20today%20are%20Microsoft%27s%20Windows%20OS%20and%20Apple%20OS.%20Linux%20is%20also%20a%20very%20popular%20operating%20system%20among%20developers.) has to be updated too. How can I update it?