### PR TITLE
Remove extra space in the "RPG game" link.

### DIFF
--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -3,12 +3,12 @@ const Results = ({ points, totalPoints, resetQuiz }) => {
     <div className="results-div" >
       <h1 className="results-heading">Results</h1>
       <h2>{points === totalPoints ? 'Wow! Perfect Score!' : 'You received'} {points} out of {totalPoints} points</h2>
-      <p className="results-text">Wanna learn how to code? Download the free
+      <p className="results-text">Wanna learn how to code? Download the free 
         <a
           className="results-rpg-link"
           target="_blank"
           rel="noopener noreferrer"
-          href="https://www.freecodecamp.org/news/learn-to-code-rpg/"> RPG game
+          href="https://www.freecodecamp.org/news/learn-to-code-rpg/">RPG game
         </a>
       </p>
       <button


### PR DESCRIPTION
In the result view, there is a space before the "RPG game" link. It's not looking good, because the underline is shown in space, and it looks like "_RPG game". So I removed a space from the start of <a> tag and added a space at end of <p> tag, and It looks fine :)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->



<!-- Feel free to add any additional description of changes below this line -->
