### PR TITLE
Add non-breaking white space for results page

### DIFF
--- a/src/components/Results.jsx
+++ b/src/components/Results.jsx
@@ -3,7 +3,7 @@ const Results = ({ points, totalPoints, resetQuiz }) => {
     <div className="results-div" >
       <h1 className="results-heading">Results</h1>
       <h2>{points === totalPoints ? 'Wow! Perfect Score!' : 'You received'} {points} out of {totalPoints} points</h2>
-      <p className="results-text">Wanna learn how to code? Download the free 
+      <p className="results-text">Wanna learn how to code? Download the free:&nbsp;
         <a
           className="results-rpg-link"
           target="_blank"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->

Results page looks like it needs a space. I've also added a semi-colon as well. Results aren't tested live, but looks like it should work based on [this tutorial](https://techstacker.com/how-to-add-white-space-between-elements-react-jsx/).

Currently:

![image](https://user-images.githubusercontent.com/2754821/163876153-595b2594-4dd9-43ac-b73c-b05f8b3307f3.png)

Update:

![image](https://user-images.githubusercontent.com/2754821/163876211-84d4fbaf-69c4-4c9f-bff8-8ff3e2cb162b.png)
