### PR TITLE
Add direct link to where quiz data lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This open source project is a work in progress and ever evolving.
 
 We welcome all contributions, suggestions and ideas for improvement from the community.
 
-You can contribute by adding new quiz questions or making changes to the code [here](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/src/data/full-quiz.js).
+You can contribute by fixing bugs in the codebase, proposing new features or adding new questions to the [quiz file](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/src/data/full-quiz.js).
 
 Make sure to first read through the [Code of Conduct](https://www.freecodecamp.org/news/code-of-conduct/).
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This open source project is a work in progress and ever evolving.
 
 We welcome all contributions, suggestions and ideas for improvement from the community.
 
-You can contribute by adding  new quiz questions or making changes to the code.
+You can contribute by adding new quiz questions or making changes to the code [here](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/src/data/full-quiz.js).
 
 Make sure to first read through the [Code of Conduct](https://www.freecodecamp.org/news/code-of-conduct/).
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Thought it would be easier for contributors to find where the data lives by putting it directly in the README.md.