### PR TITLE
fix: html abbreviation question in full-quiz.ts file

### DIFF
--- a/src/data/full-quiz.ts
+++ b/src/data/full-quiz.ts
@@ -6554,11 +6554,11 @@ const fullQuiz = [
   },
   {
     Question: "What does HTML stand for?",
-    Answer: "Hyper Text Markup Language",
+    Answer: "HyperText Markup Language",
     Distractor1: "Hyper Text Marked Language",
     Distractor2: "Hyper Text Marked Links",
     Distractor3: "Hyper Text Machine Language",
-    Explanation: "HTML stands for Hyper Text Markup Language",
+    Explanation: "HTML stands for HyperText Markup Language",
     Link: "https://www.freecodecamp.org/news/html-crash-course/",
   },
   {


### PR DESCRIPTION
I updated the HTML abbreviation question.
The old incorrect answer: Hyper Text Markup Language
New correct answer: HyperText Markup Language
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

