### PR TITLE
chore: add plural form of words and add nuance

### DIFF
--- a/src/data/full-quiz.ts
+++ b/src/data/full-quiz.ts
@@ -5616,10 +5616,10 @@ const fullQuiz = [
   {
     Question: "What does Mbps stand for?",
     Answer: "Megabits per second",
-    Distractor1: "Megabyte per second",
-    Distractor2: "Megabit per sound",
-    Distractor3: "Megabyte per system",
-    Explanation: "Mbps stands for Megabits per second.",
+    Distractor1: "Megabytes per second",
+    Distractor2: "Megabits per sound",
+    Distractor3: "Megabytes per system",
+    Explanation: "Mbps stands for Megabits per second, not to be confused with MBps (with a capital B) that stands for Megabytes per second.",
     Link: "https://en.wikipedia.org/wiki/Data-rate_units#Megabit_per_second",
   },
   {


### PR DESCRIPTION
The distractor answers should be plural like the real answer. This
commit also adds some context for some confusion around this acronym.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
