### PR TITLE
Add the chosen answer field to the results

### DIFF
--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -4,6 +4,7 @@ import React, { MouseEventHandler } from "react";
 interface QuizQuestion {
   message: string;
   points: number;
+  chosenAnswer: string;
   displayExplanation: string;
   showReference: string;
   nextQuestion: MouseEventHandler;

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -3,6 +3,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import React, { MouseEventHandler } from "react";
 
 interface QuizQuestion {
+  chosenAnswer: string;
   message: string;
   points: number;
   displayExplanation: string;
@@ -22,6 +23,10 @@ const QuizModal: React.FC<QuizQuestion> = (QuizQuestion) => {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
+          <p>
+            <b>Your Answer:</b>
+          </p>
+          <p>{QuizQuestion.chosenAnswer}</p>
           <p>
             <b>Answer:</b>
           </p>

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -24,6 +24,7 @@ const QuizTemplate: React.FC<QuizProps> = (QuizProps) => {
   const [message, setMessage] = useState("");
   const [displayExplanation, setDisplayExplanation] = useState("");
   const [showReference, setShowReference] = useState("");
+  const [chosenAnswer, setChosenAnswer] = useState("");
   const [chooseAnswer, setChooseAnswer] = useState(false);
   const [show, setShow] = useState(false);
   const [showOptions, setShowOptions] = useState(true);
@@ -91,6 +92,7 @@ const QuizTemplate: React.FC<QuizProps> = (QuizProps) => {
   const checkAnswer = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     setChooseAnswer(true);
     const userAnswer = e.currentTarget.value;
+    setChosenAnswer(userAnswer);
     if (userAnswer !== currQuestion.Answer) {
       setMessage(shuffleModalResponses(incorrectModalResponses));
       setDisplayExplanation(currQuestion.Explanation);
@@ -111,6 +113,7 @@ const QuizTemplate: React.FC<QuizProps> = (QuizProps) => {
   };
 
   const modalProps = {
+    chosenAnswer,
     message,
     points,
     displayExplanation,


### PR DESCRIPTION
This adds a property to the Quiz Question modal that gets passed around. It currently adds the chosen answer to both wrong and correct answers but it probably is okay. 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #74
<!-- Feel free to add any additional description of changes below this line -->
![How it looks with a wrong answer](https://i.imgur.com/E6GNX5V.png)

![How it looks with a right answer](https://i.imgur.com/aQlUC4d.png) 