### PR TITLE
fix: reducing content to fix browser font size issue

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,7 +11,8 @@ const HeroSection: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
         <div className="hero-text">
           <h1>Learn to Code RPG Quiz</h1>
           <h2>
-            Practice with <strong>600+</strong> Questions
+            Practice with <strong style={{ fontSize: "2rem" }}>600+</strong>{" "}
+            Questions
           </h2>
         </div>
         <div className="hero-button">

--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -23,14 +23,11 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
           style={{ backgroundColor: "#0a0a23" }}
         >
           <div className="col-md-7 content-text-container">
-            <h2 className="featurette-heading">
-              Want to test your programming knowledge?
-            </h2>
+            <h2 className="featurette-heading">Want to test your knowledge?</h2>
             <p className="lead">
-              Brush up on HTML, CSS, JavaScript, Linux, Python, Git, SQL, IT and
-              general Computer Science concepts, with 600+ questions.
+              Brush up on your programming knowledge with 600+ questions.
             </p>
-            <p className="lead">Take our quiz and have fun learning!</p>
+
             <Button
               handleClick={start}
               text="Quiz"
@@ -66,12 +63,6 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
                 freeCodeCamp.org
               </a>
               .
-            </p>
-            <p className="lead">
-              freeCodeCamp&apos;s mission is to help people learn to code for
-              free. We accomplish this by creating thousands of videos,
-              articles, and interactive coding lessons - all freely available to
-              the public.
             </p>
           </div>
           <div className="col-md-5 order-md-1 content-img-container">

--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -28,8 +28,7 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
             </h2>
             <p className="lead">
               Brush up on HTML, CSS, JavaScript, Linux, Python, Git, SQL, IT and
-              general Computer Science concepts, with{" "}
-              <span style={{ fontWeight: "700" }}>600+</span> questions.
+              general Computer Science concepts, with 600+ questions.
             </p>
             <p className="lead">Take our quiz and have fun learning!</p>
             <Button
@@ -69,10 +68,10 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
               .
             </p>
             <p className="lead">
-              freeCodeCamp&apos;s mission is to help people{" "}
-              <strong>learn to code for free</strong>. We accomplish this by
-              creating thousands of videos, articles, and interactive coding
-              lessons - all freely available to the public.
+              freeCodeCamp&apos;s mission is to help people learn to code for
+              free. We accomplish this by creating thousands of videos,
+              articles, and interactive coding lessons - all freely available to
+              the public.
             </p>
           </div>
           <div className="col-md-5 order-md-1 content-img-container">

--- a/src/stylesheets/HomepageRow.css
+++ b/src/stylesheets/HomepageRow.css
@@ -1,5 +1,5 @@
-* {
-  font-size: max(16px);
+p {
+  font-size: 19.8px;
 }
 
 .featurette-heading {

--- a/src/stylesheets/HomepageRow.css
+++ b/src/stylesheets/HomepageRow.css
@@ -1,5 +1,5 @@
-p {
-  font-size: 19.8px;
+* {
+  font-size: max(16px);
 }
 
 .featurette-heading {

--- a/src/stylesheets/HomepageRow.css
+++ b/src/stylesheets/HomepageRow.css
@@ -1,5 +1,5 @@
 p {
-  font-size: 19.8px;
+  font-size: 1.2rem;
 }
 
 .featurette-heading {


### PR DESCRIPTION
Reducing content in homepage sections to resolve text overlapping issue for browsers set to large or extra large font sizes. 
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)


Closes #85 

<!-- Feel free to add any additional description of changes below this line -->
