### PR TITLE
chore: changing distractor answers for python indentation question

### DIFF
--- a/src/data/python-quiz.ts
+++ b/src/data/python-quiz.ts
@@ -718,9 +718,9 @@ const pythonQuiz = [
     Question:
       "In Python, how many spaces are recommended per level of indentation?",
     Answer: "4",
-    Distractor1: "10",
-    Distractor2: "20",
-    Distractor3: "300",
+    Distractor1: "2",
+    Distractor2: "6",
+    Distractor3: "8",
     Explanation:
       "In Python, it is recommended to use 4 spaces per level of indentation.",
     Link: "https://www.python.org/dev/peps/pep-0008/#indentation",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This question was good, but the options were so easy that anyone would guess that the correct answer is 4 only, I changed the distractors to 2,6,8 , now the question look even thinkable than before.
