### PR TITLE
Padding Left and Right for Quiz Text(Question)

### DIFF
--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -95,6 +95,7 @@ a:hover {
 
 .quiz-text {
   display: flex;
+  padding: 0 10px;
   justify-content: space-evenly;
   font-size: 1.4rem;
 }


### PR DESCRIPTION
- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Added padding right and padding left for quiz text (question) shown on the screen, since the question was taking up 100% of screen width.