### PR TITLE
Memoize FCCLogo Component

### DIFF
--- a/src/components/FCCLogo.tsx
+++ b/src/components/FCCLogo.tsx
@@ -4,4 +4,4 @@ import fCClogo from "../images/fcc_primary_large.webp";
 const FCCLogo: React.FC = () => {
   return <img className="fcc-logo" src={fCClogo} alt="freeCodeCamp logo" />;
 };
-export default FCCLogo;
+export default React.memo(FCCLogo);


### PR DESCRIPTION
* Currently, FCCLogo Component re-renders whenever parent component (QuizTemplate) re-renders.
* Since, FCCLogo does not take in any props, it safe to wrap in React.memo(). Therefore it renders just once, instead of re-rendering for each question.

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)
