### PR TITLE
Fix: Added a media query to the button and removed extra margins from rows

### DIFF
--- a/src/components/WelcomePage.tsx
+++ b/src/components/WelcomePage.tsx
@@ -20,7 +20,7 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
 
         <div
           className="row featurette content-row-container"
-          style={{ backgroundColor: "#0a0a23" }}
+          style={{ backgroundColor: "#0a0a23", margin: "0" }}
         >
           <div className="col-md-7 content-text-container">
             <h2 className="featurette-heading">Want to test your knowledge?</h2>
@@ -49,7 +49,7 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
 
         <div
           className="row featurette content-row-container"
-          style={{ backgroundColor: "#2a2a40" }}
+          style={{ backgroundColor: "#2a2a40", margin: "0" }}
         >
           <div className="col-md-7 order-md-2 content-text-container">
             <h2 className="featurette-heading">Brand new to programming?</h2>
@@ -79,7 +79,7 @@ const WelcomePage: React.FC<{ start: MouseEventHandler<HTMLElement> }> = ({
 
         <div
           className="row featurette content-row-container"
-          style={{ backgroundColor: "#0a0a23" }}
+          style={{ backgroundColor: "#0a0a23", margin: "0" }}
         >
           <div className="col-md-7 order-md-2 content-text-container">
             <h2 style={{ marginTop: "40px" }} className="featurette-heading">

--- a/src/stylesheets/Button.css
+++ b/src/stylesheets/Button.css
@@ -35,3 +35,11 @@
   height: 70px;
   font-size: 25px;
 }
+
+@media screen and (max-width: 480px) {
+  .large-btn {
+    width: 200px;
+    height: 75px;
+    font-size: 22px;
+  }
+}

--- a/src/stylesheets/HomepageRow.css
+++ b/src/stylesheets/HomepageRow.css
@@ -13,6 +13,7 @@ p {
 
 .content-row-container {
   display: flex;
+  width: 100vw;
   align-items: center;
   justify-content: center;
   padding-top: 20px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #176 

<!-- Feel free to add any additional description of changes below this line -->
- Added a media query to the Get started button for mobile devices
-  Added an inline style to set the margin to 0 for the class 'row' which stops the problem of the 'row' class having a default margin of -12px
-  Added a 100vw width to the class 'content-row-container' so that it does exceed the screen width
