### PR TITLE
fix(question): replace section element with main element in accessibility quiz

### DIFF
--- a/src/data/accessibility-quiz.ts
+++ b/src/data/accessibility-quiz.ts
@@ -114,13 +114,13 @@ const accessibilityQuiz = [
   {
     Question:
       "Which of the following HTML elements can improve the accessibility for your website?",
-    Answer: "<section>",
+    Answer: "<main>",
     Distractor1: "<div>",
     Distractor2: "<span>",
     Distractor3: "<head>",
     Explanation:
-      "The section element holds semantic meaning and defines sections within the HTML document.",
-    Link: "https://www.freecodecamp.org/news/semantic-html5-elements/"
+      "The main element defines a main landmark on the page which allows screen reader users to quickly navigate to the beginning of the main content.",
+    Link: "https://www.freecodecamp.org/news/web-accessibility-best-practices-a11y-tips/"
   },
   {
     Question:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

The `section` element does not provide any enhanced accessibility by default. Unless you manually give it an accessible name using either the `aria-label` or `aria-labelledby` attributes it is basically the same as using a `div`. The `main` element would be a much better example to use here as it creates a main landmark by default and every page should have one. 