### PR TITLE
fix(a11y): question semantics

### DIFF
--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -27,9 +27,6 @@ const Questions: React.FC<QuizProps> = QuizProps => {
     <>
       <h1 className="quiz-heading">Question {QuizProps.questionNumber}</h1>
       <br />
-      <div className="quiz-text">
-        <h2>{QuizProps.currQuestion.Question}</h2>
-      </div>
       <div className="quiz-text mt-4">
         <p>
           Question: {QuizProps.questionNumber}/{QuizProps.totalQuestions}
@@ -41,7 +38,11 @@ const Questions: React.FC<QuizProps> = QuizProps => {
         {QuizProps.chooseAnswer ? (
           <QuizModal {...QuizProps.modalProps} />
         ) : (
-          <div className="w-50 quiz-answers-div">
+            <fieldset className="w-50 quiz-answers-div">
+              <legend>
+                <span className='sr-only'>Question {QuizProps.questionNumber}</span>{' '}
+                {QuizProps.currQuestion.Question}
+              </legend>
             <ul>
               {QuizProps.choicesArr[QuizProps.questionNumber - 1].map(
                 (btn: string | string[] | number, index: number) => (
@@ -58,7 +59,7 @@ const Questions: React.FC<QuizProps> = QuizProps => {
                 )
               )}
             </ul>
-          </div>
+          </fieldset>
         )}
       </div>
     </>

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -26,7 +26,6 @@ const Questions: React.FC<QuizProps> = QuizProps => {
   return (
     <>
       <h1 className="quiz-heading">Question {QuizProps.questionNumber}</h1>
-      <br />
       <div className="quiz-text mt-4">
         <p>
           Question: {QuizProps.questionNumber}/{QuizProps.totalQuestions}

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -42,18 +42,22 @@ const Questions: React.FC<QuizProps> = QuizProps => {
           <QuizModal {...QuizProps.modalProps} />
         ) : (
           <div className="w-50 quiz-answers-div">
-            {QuizProps.choicesArr[QuizProps.questionNumber - 1].map(
-              (btn: string | string[] | number, index: number) => (
-                <button
-                  className="answers-btns"
-                  value={btn}
-                  onClick={e => QuizProps.checkAnswer(e)}
-                  key={index}
-                >
-                  {btn}
-                </button>
-              )
-            )}
+            <ul>
+              {QuizProps.choicesArr[QuizProps.questionNumber - 1].map(
+                (btn: string | string[] | number, index: number) => (
+                  <li key={index}>
+                    <button
+                      className="answers-btns"
+                      value={btn}
+                      onClick={e => QuizProps.checkAnswer(e)}
+                      key={index}
+                    >
+                      {btn}
+                    </button>
+                  </li>
+                )
+              )}
+            </ul>
           </div>
         )}
       </div>

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -49,7 +49,6 @@ const Questions: React.FC<QuizProps> = QuizProps => {
                       className="answers-btns"
                       value={btn}
                       onClick={e => QuizProps.checkAnswer(e)}
-                      key={index}
                     >
                       {btn}
                     </button>

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -25,14 +25,13 @@ interface QuizProps {
 const Questions: React.FC<QuizProps> = QuizProps => {
   return (
     <>
-      <h1 className="quiz-heading">Question {QuizProps.questionNumber}</h1>
-      <div className="quiz-text mt-4">
+      <div className="quiz-text">
         <p>
           Question: {QuizProps.questionNumber}/{QuizProps.totalQuestions}
         </p>
         <p>Points: {QuizProps.points}</p>
       </div>
-
+      <h1 className="quiz-heading">Question {QuizProps.questionNumber}</h1>
       <div className="quiz-div">
         {QuizProps.chooseAnswer ? (
           <QuizModal {...QuizProps.modalProps} />

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -83,12 +83,15 @@ a:hover {
   margin: 20px;
 }
 
+.quiz-answers-div legend {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+}
+
 .quiz-answers-div ul {
   padding: 0;
   list-style: none;
 }
-
-
 
 .quiz-btn {
   position: absolute;

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -65,6 +65,7 @@ a:hover {
   border-radius: 15px;
   border: none;
   cursor: pointer;
+  width: 100%;
 }
 
 .quiz-btn,
@@ -81,6 +82,13 @@ a:hover {
   flex-direction: column;
   margin: 20px;
 }
+
+.quiz-answers-div ul {
+  padding: 0;
+  list-style: none;
+}
+
+
 
 .quiz-btn {
   position: absolute;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Make the underlying HTML for the question a little more accessible. I moved the question counter and points because I really feel they should not be between the question text and buttons. Personally, I view them more as something that would be in the header. Other than that, everything else should look pretty much the same on the page. It's just the HTML under the hood that has been updated for accessibility.

