### PR TITLE
feature: add category choice to quiz

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,8 +4656,6 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
       "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4672,9 +4670,7 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -21683,13 +21679,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {},
+      "requires": {
+        "ajv": "^8.0.0"
+      },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
           "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-          "optional": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -21700,9 +21697,7 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "optional": true,
-          "peer": true
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -28673,6 +28668,7 @@
         "css-has-pseudo": "^2.0.0",
         "css-prefers-color-scheme": "^5.0.0",
         "cssdb": "^5.0.0",
+        "postcss": "^8.3",
         "postcss-attribute-case-insensitive": "^5.0.0",
         "postcss-color-functional-notation": "^4.0.1",
         "postcss-color-hex-alpha": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,6 +4656,8 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
       "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4670,7 +4672,9 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -21679,14 +21683,13 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
           "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -21697,7 +21700,9 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -28668,7 +28673,6 @@
         "css-has-pseudo": "^2.0.0",
         "css-prefers-color-scheme": "^5.0.0",
         "cssdb": "^5.0.0",
-        "postcss": "^8.3",
         "postcss-attribute-case-insensitive": "^5.0.0",
         "postcss-color-functional-notation": "^4.0.1",
         "postcss-color-hex-alpha": "^8.0.0",

--- a/src/__tests__/Results.test.tsx
+++ b/src/__tests__/Results.test.tsx
@@ -8,13 +8,13 @@ describe("Results", () => {
   it("Renders without crashing", () => {
     const div = document.createElement("div");
     ReactDOM.render(
-      <Results points={0} totalPoints={10} resetQuiz={undefined} />,
+      <Results points={0} totalQuestions={10} resetQuiz={undefined} />,
       div
     );
   });
   it("Displays the accurate score for wrong answers", () => {
     const { getByText } = render(
-      <Results points={0} totalPoints={10} resetQuiz={undefined} />
+      <Results points={0} totalQuestions={10} resetQuiz={undefined} />
     );
     expect(
       getByText("You received 0 out of 10 points").textContent
@@ -22,7 +22,7 @@ describe("Results", () => {
   });
   it("Displays the perfect score message if all answers are correct", () => {
     const { getByText } = render(
-      <Results points={10} totalPoints={10} resetQuiz={undefined} />
+      <Results points={10} totalQuestions={10} resetQuiz={undefined} />
     );
     expect(
       getByText("Wow! Perfect Score! 10 out of 10 points").textContent

--- a/src/__tests__/SelectCategory.test.tsx
+++ b/src/__tests__/SelectCategory.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import SelectCategory from "../components/SelectCategory";
+import { render, cleanup, RenderResult } from "@testing-library/react";
+
+afterEach(cleanup);
+
+describe("SelectCategory", () => {
+    const selectCategoryArr = [
+      "HTML",
+      "CSS",
+      "JavaScript",
+      "Accessibility",
+      "General CS",
+      "IT",
+      "Linux",
+      "Python",
+      "SQL"
+    ];
+  
+    it("renders without crashing", () => {
+      const { getByText }: RenderResult = render(
+        <SelectCategory
+          selectCategoryArr={selectCategoryArr}
+          selectQuiz={undefined}
+          category={""}
+          selectQuizNumber={undefined}
+          startRandomQuiz={undefined}
+        />
+      );
+      expect(getByText("Choose a Category")).toBeInTheDocument();
+      });
+
+it("displays the correct categories", () => {
+        const { getByText } = render(
+            <SelectCategory
+            selectCategoryArr={selectCategoryArr}
+            selectQuiz={undefined}
+            category={""}
+            selectQuizNumber={undefined}
+            startRandomQuiz={undefined}
+          />
+        );
+        selectCategoryArr.forEach((category) => {
+            expect(getByText(category)).toBeInTheDocument();
+          });
+        expect(getByText("HTML")).toBeInTheDocument();
+        expect(getByText("CSS")).toBeInTheDocument();
+        expect(getByText("JavaScript")).toBeInTheDocument();
+      });
+});

--- a/src/__tests__/SelectCategory.test.tsx
+++ b/src/__tests__/SelectCategory.test.tsx
@@ -17,7 +17,7 @@ describe("SelectCategory", () => {
       "SQL"
     ];
   
-    it("renders without crashing", () => {
+    it("displays the Choose a Category screen", () => {
       const { getByText }: RenderResult = render(
         <SelectCategory
           selectCategoryArr={selectCategoryArr}

--- a/src/__tests__/SelectCategory.test.tsx
+++ b/src/__tests__/SelectCategory.test.tsx
@@ -5,46 +5,46 @@ import { render, cleanup, RenderResult } from "@testing-library/react";
 afterEach(cleanup);
 
 describe("SelectCategory", () => {
-    const selectCategoryArr = [
-      "HTML",
-      "CSS",
-      "JavaScript",
-      "Accessibility",
-      "General CS",
-      "IT",
-      "Linux",
-      "Python",
-      "SQL"
-    ];
-  
-    it("displays the Choose a Category screen", () => {
-      const { getByText }: RenderResult = render(
-        <SelectCategory
-          selectCategoryArr={selectCategoryArr}
-          selectQuiz={undefined}
-          category={""}
-          selectQuizNumber={undefined}
-          startRandomQuiz={undefined}
-        />
-      );
-      expect(getByText("Choose a Category")).toBeInTheDocument();
-      });
+  const selectCategoryArr = [
+    "HTML",
+    "CSS",
+    "JavaScript",
+    "Accessibility",
+    "General CS",
+    "IT",
+    "Linux",
+    "Python",
+    "SQL"
+  ];
 
-it("displays the correct categories", () => {
-        const { getByText } = render(
-            <SelectCategory
-            selectCategoryArr={selectCategoryArr}
-            selectQuiz={undefined}
-            category={""}
-            selectQuizNumber={undefined}
-            startRandomQuiz={undefined}
-          />
-        );
-        selectCategoryArr.forEach((category) => {
-            expect(getByText(category)).toBeInTheDocument();
-          });
-        expect(getByText("HTML")).toBeInTheDocument();
-        expect(getByText("CSS")).toBeInTheDocument();
-        expect(getByText("JavaScript")).toBeInTheDocument();
-      });
+  it("displays the Choose a Category screen", () => {
+    const { getByText }: RenderResult = render(
+      <SelectCategory
+        selectCategoryArr={selectCategoryArr}
+        selectQuiz={undefined}
+        category={""}
+        selectQuizNumber={undefined}
+        startRandomQuiz={undefined}
+      />
+    );
+    expect(getByText("Choose a Category")).toBeInTheDocument();
+  });
+
+  it("displays the correct categories", () => {
+    const { getByText } = render(
+      <SelectCategory
+        selectCategoryArr={selectCategoryArr}
+        selectQuiz={undefined}
+        category={""}
+        selectQuizNumber={undefined}
+        startRandomQuiz={undefined}
+      />
+    );
+    selectCategoryArr.forEach(category => {
+      expect(getByText(category)).toBeInTheDocument();
+    });
+    expect(getByText("HTML")).toBeInTheDocument();
+    expect(getByText("CSS")).toBeInTheDocument();
+    expect(getByText("JavaScript")).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/SelectQuiz.test.tsx
+++ b/src/__tests__/SelectQuiz.test.tsx
@@ -11,24 +11,24 @@ describe("Select Quiz", () => {
     ReactDOM.render(
       <SelectQuiz
         startQuiz={undefined}
-        selectQuizArr={[10, 25, 50, 100, 681]}
-      />,
+        selectQuizArr={[10, 25, 50, 100, 681]} selectedCategory={""} totalQuestions={0}      />,
       div
     );
   });
-  it("Has a button for every quiz question amount under 600", () => {
+  it("has a button for every quiz question amount under 600", () => {
     const { getByText } = render(
-      <SelectQuiz startQuiz={undefined} selectQuizArr={[10, 25, 50, 100]} />
+      <SelectQuiz startQuiz={undefined} selectQuizArr={[10, 25, 50, 100]} selectedCategory={""} totalQuestions={600} />
     );
     expect(getByText("10").textContent).toBeDefined();
     expect(getByText("25").textContent).toBeDefined();
     expect(getByText("50").textContent).toBeDefined();
-    expect(getByText("All (100)").textContent).toBeDefined();
+    expect(getByText("All (600)").textContent).toBeDefined();
   });
 
   it("Has a button for max amount equal to 601", () => {
     const { getByText } = render(
-      <SelectQuiz startQuiz={undefined} selectQuizArr={[600, 601]} />
+      <SelectQuiz startQuiz={undefined} 
+      selectQuizArr={[600, 601]} selectedCategory={""} totalQuestions={601} />
     );
     expect(getByText("All (601)").textContent).toBeDefined();
   });

--- a/src/__tests__/SelectQuiz.test.tsx
+++ b/src/__tests__/SelectQuiz.test.tsx
@@ -11,13 +11,21 @@ describe("Select Quiz", () => {
     ReactDOM.render(
       <SelectQuiz
         startQuiz={undefined}
-        selectQuizArr={[10, 25, 50, 100, 681]} selectedCategory={""} totalQuestions={0}      />,
+        selectQuizArr={[10, 25, 50, 100, 681]}
+        selectedCategory={""}
+        totalQuestions={0}
+      />,
       div
     );
   });
   it("has a button for every quiz question amount under 600", () => {
     const { getByText } = render(
-      <SelectQuiz startQuiz={undefined} selectQuizArr={[10, 25, 50, 100]} selectedCategory={""} totalQuestions={600} />
+      <SelectQuiz
+        startQuiz={undefined}
+        selectQuizArr={[10, 25, 50, 100]}
+        selectedCategory={""}
+        totalQuestions={600}
+      />
     );
     expect(getByText("10").textContent).toBeDefined();
     expect(getByText("25").textContent).toBeDefined();
@@ -27,8 +35,12 @@ describe("Select Quiz", () => {
 
   it("Has a button for max amount equal to 601", () => {
     const { getByText } = render(
-      <SelectQuiz startQuiz={undefined} 
-      selectQuizArr={[600, 601]} selectedCategory={""} totalQuestions={601} />
+      <SelectQuiz
+        startQuiz={undefined}
+        selectQuizArr={[600, 601]}
+        selectedCategory={""}
+        totalQuestions={601}
+      />
     );
     expect(getByText("All (601)").textContent).toBeDefined();
   });

--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -36,11 +36,13 @@ const Questions: React.FC<QuizProps> = QuizProps => {
         {QuizProps.chooseAnswer ? (
           <QuizModal {...QuizProps.modalProps} />
         ) : (
-            <fieldset className="w-50 quiz-answers-div">
-              <legend>
-                <span className='sr-only'>Question {QuizProps.questionNumber}</span>{' '}
-                {QuizProps.currQuestion.Question}
-              </legend>
+          <fieldset className="w-50 quiz-answers-div">
+            <legend>
+              <span className="sr-only">
+                Question {QuizProps.questionNumber}
+              </span>{" "}
+              {QuizProps.currQuestion.Question}
+            </legend>
             <ul>
               {QuizProps.choicesArr[QuizProps.questionNumber - 1].map(
                 (btn: string | string[] | number, index: number) => (

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -47,7 +47,6 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const totalQuestions = quiz.length;
   const [filteredQuestions, setFilteredQuestions] = useState(ALL_CATEGORIES);
 
-
   //detects if the user tries the refresh the page in the middle of the quiz
   useEffect(() => {
     window.addEventListener("beforeunload", alertUser);
@@ -66,33 +65,36 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const [selectedCategory, setSelectedCategory] = useState("");
   const [selectedQuiz, setSelectedQuiz] = useState(0);
 
-  const selectQuiz= (category: string, index: number) => {
+  const selectQuiz = (category: string, index: number) => {
     setSelectedCategory(category);
     setSelectedQuiz(selectQuizArr[index]);
-    setShowOptions(true); 
+    setShowOptions(true);
     setIsResults(false); // Set to false to hide Results component
     // Filter questions based on the selected category
-  const filteredQuiz = ALL_CATEGORIES.filter((q) => q.Category === category);
-  setFilteredQuestions(filteredQuiz);
-  }
+    const filteredQuiz = ALL_CATEGORIES.filter(q => q.Category === category);
+    setFilteredQuestions(filteredQuiz);
+  };
 
   const startQuiz = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    setIsReady(true)
+    setIsReady(true);
     const userAnswer = parseInt(e.currentTarget.value);
     setQuiz(shuffle(filteredQuestions).slice(0, userAnswer));
   };
 
-    // Function to start a random quiz
-    const startRandomQuiz = () => {
-      setSelectedCategory("Random"); // Set the selected category to "Random"
-      const randomIndex = Math.floor(Math.random() * selectQuizArr.length);
-      setSelectedQuiz(selectQuizArr[randomIndex]);
-      setShowOptions(true); 
-      setIsResults(false);
-      // Generate a random set of questions
-      const randomQuestions = shuffle(ALL_CATEGORIES).slice(0, selectQuizArr[randomIndex]);
-      setQuiz(randomQuestions);
-    };
+  // Function to start a random quiz
+  const startRandomQuiz = () => {
+    setSelectedCategory("Random"); // Set the selected category to "Random"
+    const randomIndex = Math.floor(Math.random() * selectQuizArr.length);
+    setSelectedQuiz(selectQuizArr[randomIndex]);
+    setShowOptions(true);
+    setIsResults(false);
+    // Generate a random set of questions
+    const randomQuestions = shuffle(ALL_CATEGORIES).slice(
+      0,
+      selectQuizArr[randomIndex]
+    );
+    setQuiz(randomQuestions);
+  };
 
   //function for toggling the react-bootstrap modal
   const handleShow = () => setShow(true);
@@ -114,7 +116,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
 
   const resetQuiz = () => {
     setSelectedCategory(""); // Reset selected category
-  setSelectedQuiz(0); // Reset selected quiz
+    setSelectedQuiz(0); // Reset selected quiz
     // setQuiz(ALL_CATEGORIES);
     setShowOptions(false);
     setIsResults(false);
@@ -149,8 +151,8 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   };
 
   const selectQuizProps = {
-    quiz, 
-    selectedCategory, 
+    quiz,
+    selectedCategory,
     selectedQuiz
   };
 
@@ -191,24 +193,28 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
       />
       <FCCLogo />
       {!showOptions ? (
-      <SelectCategory
-          selectQuizNumber={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => selectQuiz(category, 0)}
+        <SelectCategory
+          selectQuizNumber={(
+            e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+            category: string
+          ) => selectQuiz(category, 0)}
           category={selectedCategory}
           selectCategoryArr={selectCategoryArr}
-          selectQuiz={selectQuiz} 
-          startRandomQuiz={startRandomQuiz }      />
-    ) : isResults ? (
-      <Results {...resultsProps} />
-    ) : isReady ? (
-      <Questions {...questionProps}  {...modalProps} />
-    ) : (
-      <SelectQuiz
-        startQuiz={startQuiz}
-        totalQuestions={filteredQuestions.length}
-        selectQuizArr={selectQuizArr}
-        {...selectQuizProps}
-      />
-    )}
+          selectQuiz={selectQuiz}
+          startRandomQuiz={startRandomQuiz}
+        />
+      ) : isResults ? (
+        <Results {...resultsProps} />
+      ) : isReady ? (
+        <Questions {...questionProps} {...modalProps} />
+      ) : (
+        <SelectQuiz
+          startQuiz={startQuiz}
+          totalQuestions={filteredQuestions.length}
+          selectQuizArr={selectQuizArr}
+          {...selectQuizProps}
+        />
+      )}
     </>
   );
 };

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -46,6 +46,8 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const currQuestion = quiz[questionNumber - 1];
   const totalQuestions = quiz.length;
   const totalPoints = quiz.length;
+  const [filteredQuestions, setFilteredQuestions] = useState(ALL_CATEGORIES);
+
 
   //detects if the user tries the refresh the page in the middle of the quiz
   useEffect(() => {
@@ -66,18 +68,20 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const [selectedQuiz, setSelectedQuiz] = useState(0);
 
   const selectQuiz= (category: string, index: number) => {
-    console.log({showOptions});
     setSelectedCategory(category);
-  setSelectedQuiz(selectQuizArr[index]);
-  setShowOptions(true); 
-  setIsResults(false); // Set to false to hide Results component
+    setSelectedQuiz(selectQuizArr[index]);
+    setShowOptions(true); 
+    setIsResults(false); // Set to false to hide Results component
+    // Filter questions based on the selected category
+  const filteredQuiz = ALL_CATEGORIES.filter((q) => q.Category === category);
+  setFilteredQuestions(filteredQuiz);
   }
 
   const startQuiz = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     setIsReady(true)
     const userAnswer = parseInt(e.currentTarget.value);
     setQuiz(shuffle(quiz).slice(0, userAnswer));
-    console.log({isReady})
+    console.log({userAnswer})
 
   };
 

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -80,9 +80,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const startQuiz = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     setIsReady(true)
     const userAnswer = parseInt(e.currentTarget.value);
-    setQuiz(shuffle(quiz).slice(0, userAnswer));
-    console.log({userAnswer})
-
+    setQuiz(shuffle(filteredQuestions).slice(0, userAnswer));
   };
 
   //function for toggling the react-bootstrap modal

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -92,8 +92,6 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
       // Generate a random set of questions
       const randomQuestions = shuffle(ALL_CATEGORIES).slice(0, selectQuizArr[randomIndex]);
       setQuiz(randomQuestions);
-      console.log(randomQuestions)
-
     };
 
   //function for toggling the react-bootstrap modal
@@ -125,7 +123,6 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     setChooseAnswer(false);
     setPoints(0);
     setQuestionNumber(1);
-    console.log({showOptions})
   };
 
   const shuffleModalResponses = (responses: string[]) => {

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import SelectQuiz from "./SelectQuiz";
+import SelectCategory from "./SelectCategory";
 import { ALL_CATEGORIES } from "../constants";
 import Results from "./Results";
 import shuffle from "../shuffle-arr";

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -83,6 +83,20 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     setQuiz(shuffle(filteredQuestions).slice(0, userAnswer));
   };
 
+    // Function to start a random quiz
+    const startRandomQuiz = () => {
+      setSelectedCategory("Random"); // Set the selected category to "Random"
+      const randomIndex = Math.floor(Math.random() * selectCategoryArr.length);
+      setSelectedQuiz(selectQuizArr[randomIndex]);
+      setShowOptions(true); 
+      setIsResults(false);
+      // Generate a random set of questions
+      const randomQuestions = shuffle(ALL_CATEGORIES).slice(0, selectQuizArr[randomIndex]);
+      setQuiz(randomQuestions);
+      console.log(randomQuestions)
+
+    };
+
   //function for toggling the react-bootstrap modal
   const handleShow = () => setShow(true);
 
@@ -178,11 +192,11 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
       <FCCLogo />
       {!showOptions ? (
       <SelectCategory
-        selectQuizNumber={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => selectQuiz(category, 0)}
-        category={selectedCategory}
-        selectCategoryArr={selectCategoryArr}
-        selectQuiz={selectQuiz}
-      />
+          selectQuizNumber={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => selectQuiz(category, 0)}
+          category={selectedCategory}
+          selectCategoryArr={selectCategoryArr}
+          selectQuiz={selectQuiz} 
+          startRandomQuiz={startRandomQuiz }      />
     ) : isResults ? (
       <Results {...resultsProps} />
     ) : isReady ? (

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -28,7 +28,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const [chosenAnswer, setChosenAnswer] = useState("");
   const [chooseAnswer, setChooseAnswer] = useState(false);
   const [show, setShow] = useState(false);
-  const [showOptions, setShowOptions] = useState(true);
+  const [showOptions, setShowOptions] = useState(false);
   const selectQuizArr = [10, 25, 50, 100, quiz.length];
   const selectCategoryArr = [
     "HTML",
@@ -61,6 +61,16 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     e.preventDefault();
     e.returnValue = "";
   };
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const [selectedQuiz, setSelectedQuiz] = useState(0);
+
+  const selectQuiz= (category: string, index: number) => {
+    console.log({showOptions});
+    setSelectedCategory(category);
+  setSelectedQuiz(selectQuizArr[index]);
+  setShowOptions(true); 
+  setIsResults(false); // Set to false to hide Results component
+  }
 
   const startQuiz = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     setShowOptions(false);
@@ -120,14 +130,10 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   };
 
   const selectQuizProps = {
-    startQuiz,
-    selectQuizArr
+    quiz, 
+    selectedCategory, 
+    selectedQuiz
   };
-
-  const selectCategoryProps = {
-    startQuiz,
-    selectCategoryArr
-  }
 
   const modalProps = {
     chosenAnswer,
@@ -165,9 +171,18 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
         size={""}
       />
       <FCCLogo />
-      {showOptions ? (
-        // <SelectQuiz {...selectQuizProps} />
-        <SelectCategory {...selectCategoryProps} />
+      {!showOptions ? (
+        <SelectCategory
+          selectQuizNumber={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => selectQuiz(category, 0)}
+          category={selectedCategory}
+          selectCategoryArr={selectCategoryArr} 
+            selectQuiz= {selectQuiz}   />
+      ) : showOptions ? (
+        <SelectQuiz
+          startQuiz={startQuiz}
+          selectQuizArr={selectQuizArr}
+          {...selectQuizProps}
+        />
       ) : isResults ? (
         <Results {...resultsProps} />
       ) : (

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -30,6 +30,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const [show, setShow] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const selectQuizArr = [10, 25, 50, 100, quiz.length];
+  const [isReady, setIsReady] = useState(false);
   const selectCategoryArr = [
     "HTML",
     "CSS",
@@ -73,9 +74,11 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   }
 
   const startQuiz = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    setShowOptions(false);
+    setIsReady(true)
     const userAnswer = parseInt(e.currentTarget.value);
     setQuiz(shuffle(quiz).slice(0, userAnswer));
+    console.log({isReady})
+
   };
 
   //function for toggling the react-bootstrap modal
@@ -172,22 +175,23 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
       />
       <FCCLogo />
       {!showOptions ? (
-        <SelectCategory
-          selectQuizNumber={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => selectQuiz(category, 0)}
-          category={selectedCategory}
-          selectCategoryArr={selectCategoryArr} 
-            selectQuiz= {selectQuiz}   />
-      ) : showOptions ? (
-        <SelectQuiz
-          startQuiz={startQuiz}
-          selectQuizArr={selectQuizArr}
-          {...selectQuizProps}
-        />
-      ) : isResults ? (
-        <Results {...resultsProps} />
-      ) : (
-        <Questions {...questionProps} {...modalProps} />
-      )}
+      <SelectCategory
+        selectQuizNumber={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => selectQuiz(category, 0)}
+        category={selectedCategory}
+        selectCategoryArr={selectCategoryArr}
+        selectQuiz={selectQuiz}
+      />
+    ) : isResults ? (
+      <Results {...resultsProps} />
+    ) : isReady ? (
+      <Questions {...questionProps} {...modalProps} />
+    ) : (
+      <SelectQuiz
+        startQuiz={startQuiz}
+        selectQuizArr={selectQuizArr}
+        {...selectQuizProps}
+      />
+    )}
     </>
   );
 };

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -29,7 +29,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const [chooseAnswer, setChooseAnswer] = useState(false);
   const [show, setShow] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
-  const selectQuizArr = [10, 25, 50, 100, quiz.length];
+  const selectQuizArr = [10, 25, 50, 100];
   const [isReady, setIsReady] = useState(false);
   const selectCategoryArr = [
     "HTML",
@@ -80,13 +80,12 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     setIsReady(true)
     const userAnswer = parseInt(e.currentTarget.value);
     setQuiz(shuffle(filteredQuestions).slice(0, userAnswer));
-    console.log({userAnswer})
   };
 
     // Function to start a random quiz
     const startRandomQuiz = () => {
       setSelectedCategory("Random"); // Set the selected category to "Random"
-      const randomIndex = Math.floor(Math.random() * selectCategoryArr.length);
+      const randomIndex = Math.floor(Math.random() * selectQuizArr.length);
       setSelectedQuiz(selectQuizArr[randomIndex]);
       setShowOptions(true); 
       setIsResults(false);
@@ -204,10 +203,11 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     ) : isResults ? (
       <Results {...resultsProps} />
     ) : isReady ? (
-      <Questions {...questionProps} {...modalProps} />
+      <Questions {...questionProps}  {...modalProps} />
     ) : (
       <SelectQuiz
         startQuiz={startQuiz}
+        totalQuestions={filteredQuestions.length}
         selectQuizArr={selectQuizArr}
         {...selectQuizProps}
       />

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -30,6 +30,17 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const [show, setShow] = useState(false);
   const [showOptions, setShowOptions] = useState(true);
   const selectQuizArr = [10, 25, 50, 100, quiz.length];
+  const selectCategoryArr = [
+    "HTML",
+    "CSS",
+    "JavaScript",
+    "Accessibility",
+    "General CS",
+    "IT",
+    "Linux",
+    "Python",
+    "SQL"
+  ];
   const choicesArr: string[][] = [];
   const currQuestion = quiz[questionNumber - 1];
   const totalQuestions = quiz.length;
@@ -113,6 +124,11 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     selectQuizArr
   };
 
+  const selectCategoryProps = {
+    startQuiz,
+    selectCategoryArr
+  }
+
   const modalProps = {
     chosenAnswer,
     message,
@@ -150,7 +166,8 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
       />
       <FCCLogo />
       {showOptions ? (
-        <SelectQuiz {...selectQuizProps} />
+        // <SelectQuiz {...selectQuizProps} />
+        <SelectCategory {...selectCategoryProps} />
       ) : isResults ? (
         <Results {...resultsProps} />
       ) : (

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -45,7 +45,6 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   const choicesArr: string[][] = [];
   const currQuestion = quiz[questionNumber - 1];
   const totalQuestions = quiz.length;
-  const totalPoints = quiz.length;
   const [filteredQuestions, setFilteredQuestions] = useState(ALL_CATEGORIES);
 
 
@@ -171,7 +170,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
 
   const resultsProps = {
     points,
-    totalPoints,
+    totalQuestions,
     resetQuiz
   };
 

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -81,6 +81,7 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
     setIsReady(true)
     const userAnswer = parseInt(e.currentTarget.value);
     setQuiz(shuffle(filteredQuestions).slice(0, userAnswer));
+    console.log({userAnswer})
   };
 
     // Function to start a random quiz
@@ -116,13 +117,17 @@ const QuizTemplate: React.FC<QuizProps> = QuizProps => {
   };
 
   const resetQuiz = () => {
-    setQuiz(ALL_CATEGORIES);
+    setSelectedCategory(""); // Reset selected category
+  setSelectedQuiz(0); // Reset selected quiz
+    // setQuiz(ALL_CATEGORIES);
+    setShowOptions(false);
     setIsResults(false);
     setShow(false);
-    setShowOptions(true);
+    setIsReady(false);
     setChooseAnswer(false);
     setPoints(0);
     setQuestionNumber(1);
+    console.log({showOptions})
   };
 
   const shuffleModalResponses = (responses: string[]) => {

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -3,7 +3,8 @@ import React, { MouseEventHandler } from "react";
 interface PointTotals {
   points: number;
   totalPoints: number;
-  resetQuiz: MouseEventHandler<HTMLButtonElement>;
+  // resetQuiz: MouseEventHandler<HTMLButtonElement>;
+  resetQuiz: () => void;
 }
 
 const Results: React.FC<PointTotals> = ({

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -2,24 +2,24 @@ import React from "react";
 
 interface PointTotals {
   points: number;
-  totalPoints: number;
+  totalQuestions: number;
   resetQuiz: () => void;
 }
 
 const Results: React.FC<PointTotals> = ({
   points,
-  totalPoints,
+  totalQuestions,
   resetQuiz
 }: PointTotals) => {
-  const totalPercentageCorrect = (Math.floor(points) / totalPoints) * 100;
+  const totalPercentageCorrect = (Math.floor(points) / totalQuestions) * 100;
   const tweetMessage = `http://twitter.com/intent/tweet?text=I just scored ${totalPercentageCorrect}%25 on developerquiz.org. Wanna try it for yourself?&hashtags=freecodecamp`;
 
   return (
     <div className="results-div">
       <h1 className="results-heading">Results</h1>
       <h2>
-        {points === totalPoints ? "Wow! Perfect Score!" : "You received"}{" "}
-        {points} out of {totalPoints} points
+        {points === totalQuestions ? "Wow! Perfect Score!" : "You received"}{" "}
+        {points} out of {totalQuestions} points
       </h2>
       <p className="results-text">
         Wanna learn how to code? Download the free:&nbsp;

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler } from "react";
+import React from "react";
 
 interface PointTotals {
   points: number;

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -3,7 +3,6 @@ import React, { MouseEventHandler } from "react";
 interface PointTotals {
   points: number;
   totalPoints: number;
-  // resetQuiz: MouseEventHandler<HTMLButtonElement>;
   resetQuiz: () => void;
 }
 

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -2,12 +2,15 @@ import React from "react";
 
 interface SelectCategoryProps {
   category: string;
-  selectCategoryArr: string[],
+  selectCategoryArr: string[];
   selectQuiz: (category: string, index: number) => void;
-  selectQuizNumber: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => void;
+  selectQuizNumber: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    category: string
+  ) => void;
   startRandomQuiz: () => void;
 }
-  
+
 const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
   return (
     <div className="select-quiz-styles">
@@ -21,11 +24,14 @@ const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
               value={category}
               key={index}
             >
-             {category}
+              {category}
             </button>
           )
         )}
-          <button className="select-btns" onClick={SelectCategoryProps.startRandomQuiz}>
+        <button
+          className="select-btns"
+          onClick={SelectCategoryProps.startRandomQuiz}
+        >
           Random
         </button>
       </div>

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 
 interface SelectCategoryProps {
-  startQuiz: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  selectCategoryArr: string[]
+  category: string;
+  selectCategoryArr: string[],
+  selectQuiz: (category: string, index: number) => void;
+  selectQuizNumber: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => void;
 }
   
 const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
@@ -14,7 +16,7 @@ const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
           (category: string, index: number) => (
             <button
               className="select-btns"
-              onClick={e => SelectCategoryProps.startQuiz(e)}
+              onClick={() => SelectCategoryProps.selectQuiz(category, index)}
               value={category}
               key={index}
             >

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -2,26 +2,15 @@ import React from "react";
 
 interface SelectCategoryProps {
   startQuiz: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
-  SelectCategoryArr: string[]
+  selectCategoryArr: string[]
 }
-const SelectCategoryArr: string[] = [
-    "HTML",
-    "CSS",
-    "JavaScript",
-    "Accessibility",
-    "General CS",
-    "IT",
-    "Linux",
-    "Python",
-    "SQL"
-  ];
   
 const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
   return (
     <div className="select-quiz-styles">
       <h2 className="quiz-heading">Choose a Category</h2>
       <div className="w-25 select-btn-div">
-        {SelectCategoryProps.SelectCategoryArr.map(
+        {SelectCategoryProps.selectCategoryArr.map(
           (category: string, index: number) => (
             <button
               className="select-btns"

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+interface SelectCategoryProps {
+  startQuiz: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  SelectCategoryArr: string[]
+}
+const SelectCategoryArr: string[] = [
+    "HTML",
+    "CSS",
+    "JavaScript",
+    "Accessibility",
+    "General CS",
+    "IT",
+    "Linux",
+    "Python",
+    "SQL"
+  ];
+  
+const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
+  return (
+    <div className="select-quiz-styles">
+      <h2 className="quiz-heading">Choose a Category</h2>
+      <div className="w-25 select-btn-div">
+        {SelectCategoryProps.SelectCategoryArr.map(
+          (category: string, index: number) => (
+            <button
+              className="select-btns"
+              onClick={e => SelectCategoryProps.startQuiz(e)}
+              value={category}
+              key={index}
+            >
+             {category}
+            </button>
+          )
+        )}
+      </div>
+    </div>
+  );
+};
+export default SelectCategory;

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -5,6 +5,7 @@ interface SelectCategoryProps {
   selectCategoryArr: string[],
   selectQuiz: (category: string, index: number) => void;
   selectQuizNumber: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, category: string) => void;
+  startRandomQuiz: () => void;
 }
   
 const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
@@ -24,6 +25,9 @@ const SelectCategory: React.FC<SelectCategoryProps> = SelectCategoryProps => {
             </button>
           )
         )}
+          <button className="select-btns" onClick={SelectCategoryProps.startRandomQuiz}>
+          Random
+        </button>
       </div>
     </div>
   );

--- a/src/components/SelectQuiz.tsx
+++ b/src/components/SelectQuiz.tsx
@@ -8,28 +8,32 @@ interface SelectQuizProps {
 }
 
 const SelectQuiz: React.FC<SelectQuizProps> = SelectQuizProps => {
-  
-  const availableQuizLengths = SelectQuizProps.selectQuizArr.filter((length) => length <= SelectQuizProps.totalQuestions);
+  const availableQuizLengths = SelectQuizProps.selectQuizArr.filter(
+    length => length <= SelectQuizProps.totalQuestions
+  );
 
   return (
     <div className="select-quiz-styles">
       <h2 className="quiz-heading">Choose a length for the Quiz</h2>
       <div className="w-25 select-btn-div">
-      {availableQuizLengths.map((choice: number, index: number) => (
-  <button
-    className="select-btns"
-    onClick={(e) => SelectQuizProps.startQuiz(e)}
-    value={choice}
-    key={index}
-  >
-    {choice}
-  </button>
-))}
-           
-            <button className="select-btns" onClick={SelectQuizProps.startQuiz} value={SelectQuizProps.totalQuestions}>
-              All ({SelectQuizProps.totalQuestions})
-            </button>
-          
+        {availableQuizLengths.map((choice: number, index: number) => (
+          <button
+            className="select-btns"
+            onClick={e => SelectQuizProps.startQuiz(e)}
+            value={choice}
+            key={index}
+          >
+            {choice}
+          </button>
+        ))}
+
+        <button
+          className="select-btns"
+          onClick={SelectQuizProps.startQuiz}
+          value={SelectQuizProps.totalQuestions}
+        >
+          All ({SelectQuizProps.totalQuestions})
+        </button>
       </div>
     </div>
   );

--- a/src/components/SelectQuiz.tsx
+++ b/src/components/SelectQuiz.tsx
@@ -3,25 +3,33 @@ import React from "react";
 interface SelectQuizProps {
   startQuiz: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   selectQuizArr: number[];
+  selectedCategory: string; // Add the selectedCategory prop
+  totalQuestions: number; // Add the totalQuestions prop
 }
 
 const SelectQuiz: React.FC<SelectQuizProps> = SelectQuizProps => {
+  
+  const availableQuizLengths = SelectQuizProps.selectQuizArr.filter((length) => length <= SelectQuizProps.totalQuestions);
+
   return (
     <div className="select-quiz-styles">
       <h2 className="quiz-heading">Choose a length for the Quiz</h2>
       <div className="w-25 select-btn-div">
-        {SelectQuizProps.selectQuizArr.map(
-          (choice: number, index: number, array: number[]) => (
-            <button
-              className="select-btns"
-              onClick={e => SelectQuizProps.startQuiz(e)}
-              value={choice}
-              key={index}
-            >
-              {index == array.length - 1 ? `All (${choice})` : `${choice}`}
+      {availableQuizLengths.map((choice: number, index: number) => (
+  <button
+    className="select-btns"
+    onClick={(e) => SelectQuizProps.startQuiz(e)}
+    value={choice}
+    key={index}
+  >
+    {choice}
+  </button>
+))}
+           
+            <button className="select-btns" onClick={SelectQuizProps.startQuiz} value={SelectQuizProps.totalQuestions}>
+              All ({SelectQuizProps.totalQuestions})
             </button>
-          )
-        )}
+          
       </div>
     </div>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ export const ALL_CATEGORIES = [
   ...mapQuizCategory(cssQuiz, "CSS"),
   ...mapQuizCategory(cloudComputingQuiz, "Cloud Computing"),
   ...mapQuizCategory(devopsQuiz, "DevOps"),
-  ...mapQuizCategory(freecodecampQuiz, "FreeCodeCamp"),
+  ...mapQuizCategory(freecodecampQuiz, "freeCodeCamp"),
   ...mapQuizCategory(generalCSQuiz, "General CS"),
   ...mapQuizCategory(gitQuiz, "Git"),
   ...mapQuizCategory(htmlQuiz, "HTML"),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,25 +15,29 @@ import qualityAssuranceQuiz from "./data/quality-assurance-quiz";
 import securityQuiz from "./data/security-quiz";
 import sqlQuiz from "./data/sql-quiz";
 import regexQuiz from "./data/regex-quiz";
-
+const mapQuizCategory = (quiz: any[], category: string)=> {
+  return quiz.map((q) => ({ ...q, Category: category }));
+}
 export const ALL_CATEGORIES = [
-  ...accessibilityQuiz,
-  ...cssQuiz,
-  ...cloudComputingQuiz,
-  ...devopsQuiz,
-  ...freecodecampQuiz,
-  ...generalCSQuiz,
-  ...gitQuiz,
-  ...htmlQuiz,
-  ...informationTechnologyQuiz,
-  ...javascriptQuiz,
-  ...linuxQuiz,
-  ...pythonQuiz,
-  ...sqlQuiz,
-  ...agileQuiz,
-  ...qualityAssuranceQuiz,
-  ...securityQuiz,
-  ...regexQuiz
+  ...mapQuizCategory(accessibilityQuiz, "Accessibility"),
+  ...mapQuizCategory(cssQuiz, "CSS"),
+  ...mapQuizCategory(cloudComputingQuiz, "Cloud Computing"),
+  ...mapQuizCategory(devopsQuiz, "DevOps"),
+  ...mapQuizCategory(freecodecampQuiz, "FreeCodeCamp"),
+  ...mapQuizCategory(generalCSQuiz, "General CS"),
+  ...mapQuizCategory(gitQuiz, "Git"),
+  ...mapQuizCategory(htmlQuiz, "HTML"),
+  ...mapQuizCategory(informationTechnologyQuiz, "IT"),
+  ...mapQuizCategory(javascriptQuiz, "JavaScript"),
+  ...mapQuizCategory(linuxQuiz, "Linux"),
+  ...mapQuizCategory(pythonQuiz, "Python"),
+  ...mapQuizCategory(sqlQuiz, "SQL"),
+  ...mapQuizCategory(agileQuiz, "Agile"),
+  ...mapQuizCategory(qualityAssuranceQuiz, "QA"),
+  ...mapQuizCategory(securityQuiz, "Security"),
+  ...mapQuizCategory(regexQuiz, "Regex"),
 ];
+
+
 
 export const ROUNDED_QUESTION_COUNT = 1200;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,9 +15,9 @@ import qualityAssuranceQuiz from "./data/quality-assurance-quiz";
 import securityQuiz from "./data/security-quiz";
 import sqlQuiz from "./data/sql-quiz";
 import regexQuiz from "./data/regex-quiz";
-const mapQuizCategory = (quiz: any[], category: string)=> {
-  return quiz.map((q) => ({ ...q, Category: category }));
-}
+const mapQuizCategory = (quiz: any[], category: string) => {
+  return quiz.map(q => ({ ...q, Category: category }));
+};
 export const ALL_CATEGORIES = [
   ...mapQuizCategory(accessibilityQuiz, "Accessibility"),
   ...mapQuizCategory(cssQuiz, "CSS"),
@@ -35,9 +35,7 @@ export const ALL_CATEGORIES = [
   ...mapQuizCategory(agileQuiz, "Agile"),
   ...mapQuizCategory(qualityAssuranceQuiz, "QA"),
   ...mapQuizCategory(securityQuiz, "Security"),
-  ...mapQuizCategory(regexQuiz, "Regex"),
+  ...mapQuizCategory(regexQuiz, "Regex")
 ];
-
-
 
 export const ROUNDED_QUESTION_COUNT = 1200;

--- a/src/data/agile-quiz.ts
+++ b/src/data/agile-quiz.ts
@@ -1,16 +1,20 @@
 const agileQuiz = [
   {
     Question: "What are the first steps of Test Driven Development (TDD)?",
-    Answer: "Deciding what the program should do (the specifications) and formulating a failing test",
+    Answer:
+      "Deciding what the program should do (the specifications) and formulating a failing test",
     Distractor1: "Analyzing the code and deciding how many tests are needed",
-    Distractor2: "Writing out documentation and pseudo code so that the product owner knows the testing standards",
-    Distractor3: "Updating the program requirements and rendering the foundation to meet testing regulations",
+    Distractor2:
+      "Writing out documentation and pseudo code so that the product owner knows the testing standards",
+    Distractor3:
+      "Updating the program requirements and rendering the foundation to meet testing regulations",
     Explanation:
       "Before any actual code is written, the specifications and a failing test are set up. Then, the code that's written should make the test pass.",
     Link: "https://www.freecodecamp.org/news/an-introduction-to-test-driven-development-c4de6dce5c/"
-  }, 
+  },
   {
-    Question: "Which development process did Behavior Driven Development (BDD) emerge from?",
+    Question:
+      "Which development process did Behavior Driven Development (BDD) emerge from?",
     Answer: "Test Driven Development (TDD)",
     Distractor1: "Feature Driven Development (FDD)",
     Distractor2: "User Driven Development (UDD)",

--- a/src/data/css-quiz.ts
+++ b/src/data/css-quiz.ts
@@ -1254,7 +1254,8 @@ const cssQuiz = [
     Link: "https://www.freecodecamp.org/news/css-border-style-and-html-code-examples/"
   },
   {
-    Question: "In CSS, what will the following pseudo class selector do :nth-child(2)?",
+    Question:
+      "In CSS, what will the following pseudo class selector do :nth-child(2)?",
     Answer: "Selects the second child of the parent element",
     Distractor1: "Select 2 children of the parent element",
     Distractor2: "Select 2 elements of the parent element",

--- a/src/data/git-quiz.ts
+++ b/src/data/git-quiz.ts
@@ -587,7 +587,7 @@ const gitQuiz = [
       "git commit -am  '<commit message>' is used to stage and commit all changes in the current directory and its subdirectories.",
     Link: "https://git-scm.com/docs/git-commit"
   },
-    {
+  {
     Question:
       "Which git command allows you to download objects and refs from another repository without committing to the main branch?",
     Answer: "git fetch <remote> <branch>",

--- a/src/data/quality-assurance-quiz.ts
+++ b/src/data/quality-assurance-quiz.ts
@@ -119,13 +119,14 @@ const qualityAssuranceQuiz = [
   },
   {
     Question: "Which of the following is true about TDD?",
-    Answer:"With TDD, test logic precedes application logic.",
-    Distractor1:"With TDD, application logic precedes test logic",
-    Distractor2:"TDD stands for Test-Distributing Development",
-    Distractor3:"TDD stands for Testing Distributed Development",
-    Explanation:"The term TDD stands for Test-Driven Development and it is the act of first deciding what you want your program to do (the specifications), formulating a failing test, then writing the code to make that test pass.",
-    Link:"https://www.freecodecamp.org/news/an-introduction-to-test-driven-development-c4de6dce5c/",
-  },
+    Answer: "With TDD, test logic precedes application logic.",
+    Distractor1: "With TDD, application logic precedes test logic",
+    Distractor2: "TDD stands for Test-Distributing Development",
+    Distractor3: "TDD stands for Testing Distributed Development",
+    Explanation:
+      "The term TDD stands for Test-Driven Development and it is the act of first deciding what you want your program to do (the specifications), formulating a failing test, then writing the code to make that test pass.",
+    Link: "https://www.freecodecamp.org/news/an-introduction-to-test-driven-development-c4de6dce5c/"
+  }
 ];
 
 export default qualityAssuranceQuiz;

--- a/src/data/sql-quiz.ts
+++ b/src/data/sql-quiz.ts
@@ -722,7 +722,8 @@ const sqlQuiz = [
     Link: "https://www.freecodecamp.org/news/learn-sql-in-10-minutes/"
   },
   {
-    Question: "In SQL, which of the following data types holds a FIXED length string?",
+    Question:
+      "In SQL, which of the following data types holds a FIXED length string?",
     Answer: "CHAR",
     Distractor1: "VARCHAR",
     Distractor2: "TEXT",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #657 

<!-- Feel free to add any additional description of changes below this line -->
This PR adds the SelectCategory component, which allows users to choose a category for the quiz. It also moves the array of categories to `QuizTemplate` for better organization. After selecting a category, the quiz number is displayed. 

The conditional rendering of questions has been reorganized to ensure they are only rendered after selecting a number. Constants have been reworked for improved readability. The filtered category is now used to start the quiz. 

Tests have been added to ensure the component renders and displays options.

_Generated using [OpenSauced](https://opensauced.ai/)._