### PR TITLE
Add media query to stop button overflow

### DIFF
--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -131,3 +131,9 @@ a:hover {
 .results-rpg-link {
   color: #f1be32;
 }
+
+@media screen and (max-width: 460px) {
+  .select-btn-div {
+    width: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary of changes

A media query was added to the App.css file that sets the width of .select-btn-div to auto, this fixes the issue of text over flow on smaller screen sizes.

![image](https://github.com/freeCodeCamp/Developer_Quiz_Site/assets/79531561/48c4afce-4ea2-40c7-8da1-fdae32b2a131)


## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [x] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [x] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [x] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [x] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #747 
