### PR TITLE
A11y-Quiz: default landmark complementary counterpart

### DIFF
--- a/src/data/accessibility-quiz.ts
+++ b/src/data/accessibility-quiz.ts
@@ -1,6 +1,18 @@
 const accessibilityQuiz = [
   {
     Question:
+      "What is the semantic HTML counterpart to the default landmark complementary?",
+    Answer: "aside",
+    Distractor1: "contentinfo",
+    Distractor2: "section",
+    Distractor3:
+      "This default landmark does not exist.",
+    Explanation:
+      "If using semantic HTML, use the HTML tag <aside> element to define a complementary landmark.",
+    Link: "https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/complementary.html"
+  },
+  {
+    Question:
       "When creating charts, what should be added so that color is not the only identifier to convey the meaning of the information?",
     Answer: "Patterns",
     Distractor1: "Hint Buttons",

--- a/src/data/accessibility-quiz.ts
+++ b/src/data/accessibility-quiz.ts
@@ -1,14 +1,13 @@
 const accessibilityQuiz = [
   {
     Question:
-      "What is the semantic HTML counterpart to the default landmark complementary?",
+      "Which of the following HTML elements uses the default landmark complementary?",
     Answer: "aside",
     Distractor1: "contentinfo",
     Distractor2: "section",
-    Distractor3:
-      "This default landmark does not exist.",
+    Distractor3: "div",
     Explanation:
-      "If using semantic HTML, use the HTML tag <aside> element to define a complementary landmark.",
+      "The semantic <aside> element uses the complementary landmark which is a supporting section of the document created to complement the main content.",
     Link: "https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/complementary.html"
   },
   {


### PR DESCRIPTION
## Summary of changes

<!-- Please provide a quick summary of the changes made in this PR -->

For the a11y quiz I created a question regarding the counterpart of the default landmark complementary when using semantic HTML.

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [x] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [x] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [x] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [x] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #XXXXX
