### PR TITLE
fix: Responsive Layout Enhancement for Quiz Container

### DIFF
--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -39,7 +39,7 @@ const Questions: React.FC<QuizProps> = QuizProps => {
         {QuizProps.chooseAnswer ? (
           <QuizModal {...QuizProps.modalProps} />
         ) : (
-          <fieldset className="w-50 quiz-answers-div">
+          <fieldset className="quiz-answers-div">
             <legend>
               <span className="sr-only">
                 Question {QuizProps.questionNumber}

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -85,6 +85,7 @@ a:hover {
   display: flex;
   flex-direction: column;
   margin: 20px;
+  width: 50%;
 }
 
 .quiz-answers-div legend {
@@ -146,5 +147,9 @@ a:hover {
 @media screen and (max-width: 460px) {
   .select-btn-div {
     width: auto !important;
+  }
+
+  .quiz-answers-div {
+    width: auto;
   }
 }


### PR DESCRIPTION
## Summary of changes

The current layout of the quiz container, which displays the question, options, and submit button, utilizes the `w-50` class for a 50% width. While this approach works well on larger screens, it presents usability challenges on mobile devices due to their limited screen real estate.

**Implementation**
- Removed the `w-50` class from the quiz container.
- Added a media query targeting devices with screen widths less than `460px`. Within this rule, the container's width is set to 100%, ensuring it occupies the full width of the mobile screen and improves user experience.

**Attached full screenshot showing after changing the width to `100%` in mobile devices**

![freeCodeCamp-Developer-Quiz-After](https://github.com/freeCodeCamp/Developer_Quiz_Site/assets/54032677/4c2133f1-ab1a-47ad-bcb8-f346f1af0a5e)


## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [x] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [x] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [x] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [x] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #926
