### PR TITLE
fix: refresh browser should navigate to quizzes page

### DIFF
--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -1,5 +1,6 @@
+import { useNavigate } from "react-router-dom";
 import QuizModal from "./QuizModal";
-import React, { MouseEventHandler } from "react";
+import React, { MouseEventHandler, useEffect } from "react";
 
 interface QuizQuestion {
   message: string;
@@ -26,6 +27,12 @@ interface QuizProps {
 }
 
 const Questions: React.FC<QuizProps> = QuizProps => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (!QuizProps.choicesArr.length) {
+      navigate("/quizzes");
+    }
+  }, [QuizProps.choicesArr]);
   return (
     <>
       <div className="quiz-text">


### PR DESCRIPTION
## Summary of changes

prevent 404 from appear when refreshing browser

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [x] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [x] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [x] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [x] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #939 
