### PR TITLE
refactor: when selecting total-questions-of-quiz - better to pass number

### DIFF
--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -63,9 +63,11 @@ const QuizTemplate: React.FC = () => {
     navigate(`/quizzes/${category}/questionsTotal`);
   };
 
-  const startQuiz = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    const userAnswer = parseInt(e.currentTarget.value);
-    const shuffledQuiz = shuffle(filteredQuestions).slice(0, userAnswer);
+  const startQuiz = (quizQuestionsCount: number) => {
+    const shuffledQuiz = shuffle(filteredQuestions).slice(
+      0,
+      quizQuestionsCount
+    );
 
     // Shuffle the answer options
     const choicesArr: string[][] = shuffledQuiz.map(obj => {
@@ -80,7 +82,9 @@ const QuizTemplate: React.FC = () => {
 
     setQuiz(shuffledQuiz);
     setChoicesArr(choicesArr);
-    navigate(`/quizzes/${selectedCategory}/questions/1/of/${userAnswer}`);
+    navigate(
+      `/quizzes/${selectedCategory}/questions/1/of/${quizQuestionsCount}`
+    );
   };
 
   // Function to start a random quiz

--- a/src/components/SelectQuestionsTotal.tsx
+++ b/src/components/SelectQuestionsTotal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { QUESTION_NUMS } from "../constants";
 
 interface SelectQuestionsTotalProps {
-  startQuiz: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  startQuiz: (e: number) => void;
   selectedCategory: string; // Add the selectedCategory prop
   totalQuestions: number; // Add the totalQuestions prop
 }
@@ -22,8 +22,7 @@ const SelectQuestionsTotal: React.FC<SelectQuestionsTotalProps> = ({
         {availableQuizLengths.map((choice: number, index: number) => (
           <button
             className="select-btns"
-            onClick={e => startQuiz(e)}
-            value={choice}
+            onClick={() => startQuiz(choice)}
             key={index}
           >
             {choice}
@@ -32,8 +31,7 @@ const SelectQuestionsTotal: React.FC<SelectQuestionsTotalProps> = ({
 
         <button
           className="select-btns"
-          onClick={startQuiz}
-          value={totalQuestions}
+          onClick={() => startQuiz(totalQuestions)}
         >
           All ({totalQuestions})
         </button>


### PR DESCRIPTION
## Summary of changes

 when selecting total-questions-of-quiz - better to pass number instead of passing mouse event

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [x] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [x] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [x] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [x] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #XXXXX
