### PR TITLE
feat(UI): make selected answer pop

### DIFF
--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -121,7 +121,7 @@ a:hover {
   color: #ffffff;
   background-color: transparent;
   opacity: 0.5;
-  border: white;
+  border: 2px solid #ffffff;
 }
 
 /*Modal styles*/

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -74,14 +74,14 @@ a:hover {
   box-shadow: -1px -1px 15px rgb(245 242 247 / 70%);
 }
 .answers-btns--selected {
-  background-color: #cccccc;
+  background-color: #f1be32;
 }
 
 .quiz-btn,
 .results-btn,
 .modal-btn {
-  background-color: #f1be32;
-  border: 3px solid #feac32;
+  background-color: #acd157;
+  border: 3px solid #acd157;
   font-size: 1.2rem;
   padding: 5px;
 }

--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -119,8 +119,9 @@ a:hover {
 .submit-btn {
   font-weight: bold;
   color: #ffffff;
-  background-color: #acd157;
+  background-color: transparent;
   opacity: 0.5;
+  border: white;
 }
 
 /*Modal styles*/


### PR DESCRIPTION
## Summary of changes

<!-- Please provide a quick summary of the changes made in this PR -->
This PR sets the selected answer color as goldenrod and set the other button colors to lime. I think at some point we should consider adding a dark mode toggle but there's no rush. 

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [X] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [X] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [X] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [X] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #965