### PR TITLE
fix: remove unused event handler

### DIFF
--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -223,10 +223,7 @@ const QuizTemplate: React.FC = () => {
           path="/"
           element={
             <SelectCategory
-              selectQuizNumber={(
-                e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-                category: string
-              ) => selectQuiz(category, 0)}
+              selectQuizNumber={(category: string) => selectQuiz(category, 0)}
               category={selectedCategory}
               selectQuiz={selectQuiz}
               startRandomQuiz={startRandomQuiz}

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -4,10 +4,7 @@ import { CATEGORIES } from "../constants";
 interface SelectCategoryProps {
   category: string;
   selectQuiz: (category: string, index: number) => void;
-  selectQuizNumber: (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    category: string
-  ) => void;
+  selectQuizNumber: (category: string) => void;
   startRandomQuiz: () => void;
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please provide a quick summary of the changes made in this PR -->
This removes the event handler defined in the `SelectCategoryProps` properties as per the instructions. I have tested the codebase and everything seems fine. 
## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [X] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [X] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [X] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [X] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #1039