### PR TITLE
refactor: remove selectQuizNumber prop form selectCategory component

### DIFF
--- a/src/__tests__/SelectCategory.test.tsx
+++ b/src/__tests__/SelectCategory.test.tsx
@@ -23,7 +23,6 @@ describe("SelectCategory", () => {
       <SelectCategory
         selectQuiz={undefined}
         category={""}
-        selectQuizNumber={undefined}
         startRandomQuiz={undefined}
       />
     );
@@ -35,7 +34,6 @@ describe("SelectCategory", () => {
       <SelectCategory
         selectQuiz={undefined}
         category={""}
-        selectQuizNumber={undefined}
         startRandomQuiz={undefined}
       />
     );

--- a/src/components/QuizTemplate.tsx
+++ b/src/components/QuizTemplate.tsx
@@ -121,7 +121,6 @@ const QuizTemplate: React.FC = () => {
   const resetQuiz = () => {
     setSelectedCategory(""); // Reset selected category
     setSelectedQuiz(0); // Reset selected quiz
-    // setQuiz(ALL_CATEGORIES);
     setShow(false);
     setChooseAnswer(false);
     setPoints(0);
@@ -223,7 +222,6 @@ const QuizTemplate: React.FC = () => {
           path="/"
           element={
             <SelectCategory
-              selectQuizNumber={(category: string) => selectQuiz(category, 0)}
               category={selectedCategory}
               selectQuiz={selectQuiz}
               startRandomQuiz={startRandomQuiz}

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -4,7 +4,6 @@ import { CATEGORIES } from "../constants";
 interface SelectCategoryProps {
   category: string;
   selectQuiz: (category: string, index: number) => void;
-  selectQuizNumber: (category: string) => void;
   startRandomQuiz: () => void;
 }
 


### PR DESCRIPTION
## Summary of changes
since the purpose of this component is - to select categories   
looks like this method not used anywhere at app, and was copied to this component by mistake...

<!-- Please provide a quick summary of the changes made in this PR -->

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [x] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [x] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [x] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [x] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #XXXXX
