### PR TITLE
fix: add missing 'correct' field to QuizQuestion interface to remove the bug in QuizModalProps

### DIFF
--- a/src/components/Questions.tsx
+++ b/src/components/Questions.tsx
@@ -6,6 +6,7 @@ interface QuizQuestion {
   message: string;
   points: number;
   chosenAnswer: string;
+  correct: boolean;
   displayExplanation: string;
   showReference: string;
   nextQuestion: MouseEventHandler;


### PR DESCRIPTION


## Summary of changes

Fixed the bug in Question.tsx it was missing correct(boolean) field

## Checklist



- [✅ ] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [✅ ] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [ ✅] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [ ✅] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [ ✅] I have provided a summary of my changes.



closes #1151
