### PR TITLE
fix(ui): use percentages for content row container height

### DIFF
--- a/src/stylesheets/App.css
+++ b/src/stylesheets/App.css
@@ -57,7 +57,7 @@ a:hover {
 .select-btn-div {
   display: flex;
   flex-direction: column;
-  margin: 20px;
+  margin: 1.25rem;
   width: 100%;
   padding: 0 10% 0;
 }
@@ -96,7 +96,7 @@ a:hover {
 .quiz-answers-div {
   display: flex;
   flex-direction: column;
-  margin: 20px;
+  margin: 1.25rem;
   width: 50%;
 }
 
@@ -138,7 +138,7 @@ hr {
 /* Results styles */
 .results-text {
   font-size: 1.3rem;
-  margin-top: 20px;
+  margin-top: 1.25rem;
 }
 
 .results-rpg-link {

--- a/src/stylesheets/HeroSection.css
+++ b/src/stylesheets/HeroSection.css
@@ -13,7 +13,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   position: relative;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   box-shadow: inset 0 0 0 1000px rgb(34 27 49 / 57%);
   object-fit: contain;
@@ -25,7 +25,7 @@
 }
 
 .hero-text {
-  padding: 20px;
+  padding: 1.25rem;
   font-family: Lato, sans-serif;
   text-align: center;
   letter-spacing: 1px;

--- a/src/stylesheets/HomepageRow.css
+++ b/src/stylesheets/HomepageRow.css
@@ -18,8 +18,8 @@ p {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
   background-color: var(--bg-primary);
 }
 
@@ -29,7 +29,7 @@ p {
   flex-wrap: wrap;
   align-content: center;
   justify-content: center;
-  padding: 20px 30px !important;
+  padding: 1.25rem 30px !important;
 }
 
 .lead {
@@ -62,13 +62,13 @@ p {
 #fcc-image {
   width: 100%;
   height: 100%;
-  padding-left: 10px;
+  padding-left: 0.625em;
   object-fit: contain;
 }
 
 @media screen and (min-width: 768px) {
   .content-row-container {
-    height: 400px;
+    height: 10%;
   }
 
   .content-main-container {

--- a/src/stylesheets/Navbar.css
+++ b/src/stylesheets/Navbar.css
@@ -1,11 +1,11 @@
 @import "./colors.css";
 
 header {
-  height: 55px;
+  height: 3rem;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 10px;
+  padding: 0.625rem;
   background-color: var(--bg-primary);
 }
 


### PR DESCRIPTION
## Summary of changes

<!-- Please provide a quick summary of the changes made in this PR -->
This makes the height of the row container grow and shrink relative to the screen height rather than use fixed height when zoomed in. I also updated some of the units to be `rem` instead of `px`. 


## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read and followed the [contribution guidelines](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CONTRIBUTING.md).
- [X] I have read through the [Code of Conduct](https://github.com/freeCodeCamp/Developer_Quiz_Site/blob/main/CODE_OF_CONDUCT.md) and agree to abide by the rules.
- [X] This PR is for one of the available issues and is not a PR for an issue already assigned to someone else.
- [X] My PR title has a short descriptive name so the maintainers can get an idea of what the PR is about.
- [X] I have provided a summary of my changes.

<!--If you are working on an issue that has been assigned to you, then replace the XXXXX below with the issue number.-->

closes #1280
